### PR TITLE
Fix storage quota validation error

### DIFF
--- a/src/Http/Controllers/Api/StorageRequestUserController.php
+++ b/src/Http/Controllers/Api/StorageRequestUserController.php
@@ -23,7 +23,7 @@ class StorageRequestUserController extends Controller
     public function store(Request $request, $id)
     {
         $request->validate([
-            'quota' => 'required|integer|min:0',
+            'quota' => 'required|numeric|min:0',
         ]);
 
         $user = User::findOrFail($id);

--- a/tests/Http/Controllers/Api/StorageRequestUserControllerTest.php
+++ b/tests/Http/Controllers/Api/StorageRequestUserControllerTest.php
@@ -35,5 +35,13 @@ class StorageRequestUserControllerTest extends ApiTestCase
             ->assertStatus(200);
 
         $this->assertEquals(200, $user->fresh()->storage_quota_available);
+
+        $this
+        ->postJson("/api/v1/users/{$user->id}/storage-request-quota", [
+            'quota' => "1E+11",
+        ])
+        ->assertStatus(200);
+
+        $this->assertEquals(1E+11, $user->fresh()->storage_quota_available);
     }
 }


### PR DESCRIPTION
Replace 'integer' by 'numeric' in validation rule.
    
Fixes #25