### PR TITLE
Change re-upload behaviour of storage requests

### DIFF
--- a/src/resources/assets/js/createContainer.vue
+++ b/src/resources/assets/js/createContainer.vue
@@ -6,7 +6,7 @@ import {LoaderMixin, handleErrorResponse, FileBrowserComponent} from './import';
 import {sizeForHumans} from './utils';
 
 // Number of times a file upload is retried.
-const RETRY_UPLOAD = 2;
+const RETRY_UPLOAD = 3;
 
 export default {
     mixins: [LoaderMixin],

--- a/src/resources/assets/js/createContainer.vue
+++ b/src/resources/assets/js/createContainer.vue
@@ -430,9 +430,9 @@ export default {
                     if (e.status >= 500 && retryCount < RETRY_UPLOAD) {
                         // Add delay to prevent failing uploads due to e.g. BIIGLE instance updates or
                         // short moments of unavailability.
-                        setTimeout(
-                            () => {return this.uploadBlob(blob, prefix, chunkIndex, totalChunks, retryCount + 1)},
-                            5000);
+                        return new Vue.Promise((resolve) => {
+                            setTimeout(() => resolve(this.uploadBlob(blob, prefix, chunkIndex, totalChunks, retryCount + 1)), 5000);
+                        });
                     }
                     
                     throw e;

--- a/src/resources/assets/js/createContainer.vue
+++ b/src/resources/assets/js/createContainer.vue
@@ -434,7 +434,6 @@ export default {
                             setTimeout(() => resolve(this.uploadBlob(blob, prefix, chunkIndex, totalChunks, retryCount + 1)), 5000);
                         });
                     }
-                    
                     throw e;
                 });
         },

--- a/src/resources/assets/js/createContainer.vue
+++ b/src/resources/assets/js/createContainer.vue
@@ -428,9 +428,13 @@ export default {
                     // Try uploading again on server error until number of retries is
                     // reached.
                     if (e.status >= 500 && retryCount < RETRY_UPLOAD) {
-                        return this.uploadBlob(blob, prefix, chunkIndex, totalChunks, retryCount + 1);
+                        // Add delay to prevent failing uploads due to e.g. BIIGLE instance updates or
+                        // short moments of unavailability.
+                        setTimeout(
+                            () => {return this.uploadBlob(blob, prefix, chunkIndex, totalChunks, retryCount + 1)},
+                            5000);
                     }
-
+                    
                     throw e;
                 });
         },


### PR DESCRIPTION
Increased the number of retries to 3 and added an 5s delay before re-uploading files.

References #11.