### PR TITLE
Show warning if TIFF

### DIFF
--- a/src/resources/assets/js/createContainer.vue
+++ b/src/resources/assets/js/createContainer.vue
@@ -38,6 +38,7 @@ export default {
             failedFiles: [],
             nbrDuplicatedFiles: 0,
             ignoreFiles: false,
+            hasTIFF: 0,
         };
     },
     computed: {
@@ -120,6 +121,9 @@ export default {
                 || (nbrFailedFiles === this.files.length)
                 || (this.nbrDuplicatedFiles + nbrFailedFiles) === this.files.length;
         },
+        hasTIFFfile() {
+            return this.hasTIFF > 0;
+        },
     },
     methods: {
         computeTotalSize(files){
@@ -177,6 +181,9 @@ export default {
                     this.pathContainsSpaces = true;
                     let newName = newFiles[i].name.replace(/ /g, '_');
                     file = new File([newFiles[i]], newName, { type: newFiles[i].type });
+                }
+                if (file.type == "image/tiff") {
+                    this.hasTIFF += 1;
                 }
                 file._status = {
                     failed: false,
@@ -308,6 +315,9 @@ export default {
             promise.then(() => {
                 let index = files.indexOf(file);
                 if (index !== -1) {
+                    if (files[index].type == "image/tiff") {
+                        this.hasTIFF -= 1;
+                    }
                     files.splice(index, 1);
                 }
 

--- a/src/resources/views/create.blade.php
+++ b/src/resources/views/create.blade.php
@@ -181,6 +181,10 @@
             They already exist in another storage request with equal directory name.
         </p>
 
+        <p v-cloak v-if="hasTIFFfile" class="text-info">
+            Only large TIFF files (10,000+ px) are supported. Smaller files may not work.
+        </p>
+        
         <p v-cloak v-if="!finished && hasFiles" class="text-muted">
             <span v-if="finishIncomplete">Failed files with a total size of <span v-text="totalSizeFailedFilesForHumans"></span>.</span> 
             <span v-else>Selected files with a total size of <span v-text="totalSizeForHumans"></span>.</span>


### PR DESCRIPTION
This update introduces a warning message when a user adds a TIFF file to the upload list and closes #22 

- Displays a notification indicating that only large TIFF files (10,000+ px) are supported.